### PR TITLE
jmx-file for gui-tasks are now optional (#20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
 
   publishSnapshot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.ref == 'develop'
+    if: github.ref == 'refs/heads/develop'
     needs:
       - report
       - licenceCheck
@@ -184,7 +184,7 @@ jobs:
           path: ${{ github.workspace }}/build/**
           key: ${{ runner.os }}-compile-${{ github.run_id }}
 
-      - name: "Publish"
+      - name: "Publish snapshot"
         uses: burrunan/gradle-cache-action@v1
         env:
           USERNAME: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
+### Fixed
+- JMX-File now is really optional for gui tasks (#20)
 
 ## [2.0.0]
 ### Added

--- a/src/main/kotlin/de/qualersoft/jmeter/gradleplugin/task/JMeterBaseTask.kt
+++ b/src/main/kotlin/de/qualersoft/jmeter/gradleplugin/task/JMeterBaseTask.kt
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.jar.JarFile
@@ -104,6 +105,7 @@ abstract class JMeterBaseTask : JavaExec() {
    */
   @Input
   @Optional
+  @Option(option = "t", description = "the jmeter test(.jmx) file to run")
   val jmxFile: Property<String> = objectFactory.property(String::class.java)
 
   /**
@@ -113,6 +115,7 @@ abstract class JMeterBaseTask : JavaExec() {
    */
   @get:InputFile
   @get:PathSensitive(PathSensitivity.ABSOLUTE)
+  @get:Optional
   internal val sourceFile: RegularFileProperty = objectFactory.fileProperty().fileProvider(resolveJmxFile())
 
   /**


### PR DESCRIPTION
Fixes #20 
also added `--t` cmdl option to tasks