### PR TITLE
Fix Gradle 10 dependency notation

### DIFF
--- a/src/main/kotlin/de/qualersoft/jmeter/gradleplugin/JMeterConfig.kt
+++ b/src/main/kotlin/de/qualersoft/jmeter/gradleplugin/JMeterConfig.kt
@@ -79,7 +79,7 @@ class JMeterConfig(private val project: Project) {
    */
   fun applyTo(config: Configuration) {
     config.dependencies.add(createJMeterLibDependency())
-    val toolConfigDepNot = createToolConfigDependencyNotion()
+    val toolConfigDepNot = jmeterDependencyNotation("config")
     val toolConfigDep = project.dependencies.create(toolConfigDepNot)
     config.dependencies.add(applyBomWorkaround(toolConfigDep))
   }
@@ -89,7 +89,7 @@ class JMeterConfig(private val project: Project) {
       "bolt", "components", "core", "ftp", "functions", "http", "java", "jdbc", "jms", "junit", "ldap",
       "mail", "mongodb", "native", "tcp"
     ).forEach {
-      val depNot = jmeterDependency(it)
+      val depNot = jmeterDependencyNotation(it)
       val dep = project.dependencies.create(depNot)
       logger.debug("Adding dependency for {}", dep)
       config.dependencies.add(applyBomWorkaround(dep))
@@ -117,13 +117,13 @@ class JMeterConfig(private val project: Project) {
     return dependency
   }
 
-  private fun createToolDependencyNotation(): Map<String, String> = mutableMapOf<String, String>().also { res ->
-    res["group"] = group
-    res["name"] = name
-    res["version"] = version
-  }
+  private fun createToolDependencyNotation(): String = "$group:$name:$version"
 
-  fun createToolConfigDependencyNotion(): Map<String, String> = jmeterDependency("config")
+  fun createToolConfigDependencyNotion(): Map<String, String> = mapOf(
+    "group" to group,
+    "name" to "ApacheJMeter_config",
+    "version" to version
+  )
 
   /**
    * Creates a dependency notation for a jmeter core extension where group is [group].
@@ -131,9 +131,6 @@ class JMeterConfig(private val project: Project) {
    * @param name The name of the extension. The `ApacheJMeter_` will be prepended.
    * @param version The version to use, defaults to [JMeterConfig.version]
    */
-  fun jmeterDependency(name: String, version: String = this.version) = mutableMapOf<String, String>().also {
-    it["group"] = group
-    it["name"] = "ApacheJMeter_$name"
-    it["version"] = version
-  }
+  private fun jmeterDependencyNotation(name: String, version: String = this.version): String =
+    "$group:ApacheJMeter_$name:$version"
 }


### PR DESCRIPTION
## Summary

- Create JMeter runner, configuration, and component dependencies with Gradle's canonical single-string coordinates.
- Preserve the existing map-returning helper used to find the configuration artifact after resolution.

## Why

Gradle 9 deprecates map/multi-string dependency notation and will reject it in Gradle 10. The plugin creates 15 such dependencies during project configuration.

## Validation

- `./gradlew compileKotlin`
- Gradle 9.6.1 consumer build: `--warning-mode all help` — successful, with no dependency-notation warnings.

The full upstream `functionalTest` suite was started but stopped after its nested Gradle test builds ran for over five minutes without producing JUnit XML; that test-infrastructure behaviour is unrelated to this change.
